### PR TITLE
setting prettier parser option for CSS files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,14 +77,20 @@ function format(options) {
     }),
   )
 
-  const isCss = /\.(css|less|scss)$/.test(filePath);
-  if (isCss) formattingOptions.prettier.parser = 'postcss';
+  const isCss = /\.(css|less|scss)$/.test(filePath)
+  if (isCss) {
+    formattingOptions.prettier.parser = 'postcss'
+  }
   const prettify = createPrettify(formattingOptions.prettier, prettierPath)
   const eslintFix = createEslintFix(formattingOptions.eslint, eslintPath)
 
-  return isCss ? prettify(text, filePath) :
-    prettierLast ? prettify(eslintFix(text, filePath)) :
-    eslintFix(prettify(text), filePath);
+  if (isCss) {
+    return prettify(text, filePath)'
+  }
+  if (prettierLast) {
+    return prettify(eslintFix(text, filePath))
+  }
+  return eslintFix(prettify(text), filePath)
 }
 
 function createPrettify(formatOptions, prettierPath) {

--- a/src/index.js
+++ b/src/index.js
@@ -77,14 +77,14 @@ function format(options) {
     }),
   )
 
+  const isCss = /\.(css|less|scss)$/.test(filePath);
+  if (isCss) formattingOptions.prettier.parser = 'postcss';
   const prettify = createPrettify(formattingOptions.prettier, prettierPath)
   const eslintFix = createEslintFix(formattingOptions.eslint, eslintPath)
 
-  if (prettierLast) {
-    return prettify(eslintFix(text, filePath))
-  }
-
-  return eslintFix(prettify(text), filePath)
+  return isCss ? prettify(text, filePath) :
+    prettierLast ? prettify(eslintFix(text, filePath)) :
+    eslintFix(prettify(text), filePath);
 }
 
 function createPrettify(formatOptions, prettierPath) {

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ function format(options) {
   const eslintFix = createEslintFix(formattingOptions.eslint, eslintPath)
 
   if (isCss) {
-    return prettify(text, filePath)'
+    return prettify(text, filePath)
   }
   if (prettierLast) {
     return prettify(eslintFix(text, filePath))


### PR DESCRIPTION
Prettier supports the `parser` option to indicate the parser to be used when parsing text rather than a file.
This is necessary because it's difficult to detect the source file type without a file extension.
This fix uses the same logic Prettier does to determine if the parser should be `postcss`.
It also avoids running ESLint on .css, .less, and .scss files.